### PR TITLE
Remove calls to comScore UX API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,5 +17,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.comscore:android-analytics:5.0.4'
+    compile 'com.comscore:android-analytics:5.0.6'
 }

--- a/src/main/java/com/mparticle/kits/ComscoreKit.java
+++ b/src/main/java/com/mparticle/kits/ComscoreKit.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.Map;
 
 
-public class ComscoreKit extends KitIntegration implements KitIntegration.EventListener, KitIntegration.AttributeListener, KitIntegration.ActivityListener, KitIntegration.SessionListener {
+public class ComscoreKit extends KitIntegration implements KitIntegration.EventListener, KitIntegration.AttributeListener, KitIntegration.ActivityListener {
 
     private static final String CLIENT_ID = "CustomerC2Value";
     private static final String PUBLISHER_SECRET = "PublisherSecret";
@@ -221,26 +221,6 @@ public class ComscoreKit extends KitIntegration implements KitIntegration.EventL
         messageList.add(
                 new ReportingMessage(this, ReportingMessage.MessageType.OPT_OUT, System.currentTimeMillis(), null)
                         .setOptOut(optOutStatus)
-        );
-        return messageList;
-    }
-
-    @Override
-    public List<ReportingMessage> onSessionStart() {
-        Analytics.notifyUxActive();
-        List<ReportingMessage> messageList = new LinkedList<ReportingMessage>();
-        messageList.add(
-                new ReportingMessage(this, ReportingMessage.MessageType.SESSION_START, System.currentTimeMillis(), null)
-        );
-        return messageList;
-    }
-
-    @Override
-    public List<ReportingMessage> onSessionEnd() {
-        Analytics.notifyUxInactive();
-        List<ReportingMessage> messageList = new LinkedList<ReportingMessage>();
-        messageList.add(
-                new ReportingMessage(this, ReportingMessage.MessageType.SESSION_END, System.currentTimeMillis(), null)
         );
         return messageList;
     }


### PR DESCRIPTION
comScore's notion of a user experience and the requirements for
measuring its length are different than mParticle sessions. Only
apps that have background streaming functionality should use these
APIs, and they should be invoked immediately as/after media starts
or stops. In those cases, apps can make direct APIs calls to the
comScore SDK.