### PR TITLE
Update comScore to 5.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,5 +17,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.comscore:android-analytics:5.0.6'
+    compile 'com.comscore:android-analytics:5.2.0'
 }


### PR DESCRIPTION
Nothing major in their change logs, so it looks like all we need to do is update the dependency