### PR TITLE
chore: pin mparticle dependency to [5.0,6.0) range

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,9 @@
 buildscript {
     ext.kotlin_version = '2.0.20'
     if (!project.hasProperty('version') || project.version.equals('unspecified')) {
-        project.version = '+'
+        // Bounded range avoids resolving to 6.0.0-rc.1+ on Maven Central when
+        // built standalone. The mparticle-android-sdk CI passes -Pversion explicitly.
+        project.version = '[5.0,6.0)'
     }
 
     repositories {


### PR DESCRIPTION
## Summary

- Replace the open-ended `project.version = '+'` fallback in the standalone build with a bounded range `[5.0,6.0)`.
- Prevents the kit from pulling `com.mparticle:android-kit-plugin:6.0.0-rc.1` (and transitively `android-kit-base:6.0.0-rc.1`) from Maven Central when built outside the [mparticle-android-sdk](https://github.com/mParticle/mparticle-android-sdk) monorepo.

## Why

`6.0.0-rc.1` was published to Maven Central on 2026-05-22. It renamed `KitIntegration.AttributeListener` → `ModifyIdentityListener` and removed several deprecated symbols. With `project.version = '+'`, Gradle resolves to the highest available version (the RC) and standalone builds fail to compile against the 5.x kit source.

The mparticle-android-sdk release pipeline is being updated in parallel to pass `-Pversion=<sdk-version>` to standalone kit builds, so this range only kicks in for ad-hoc/external builds — but it's the right safety net.

## Test plan

- [ ] `./gradlew lint` succeeds standalone after the parent SDK is published to mavenLocal.
- [ ] `./gradlew testRelease publishReleaseLocal` succeeds standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)